### PR TITLE
Add missing generic parameters

### DIFF
--- a/src/yandex_cloud_ml_sdk/_models/completions/function.py
+++ b/src/yandex_cloud_ml_sdk/_models/completions/function.py
@@ -27,9 +27,9 @@ class BaseCompletions(BaseModelFunction[ModelTypeT]):
         )
 
 
-class Completions(BaseCompletions):
+class Completions(BaseCompletions[GPTModel]):
     _model_type = GPTModel
 
 
-class AsyncCompletions(BaseCompletions):
+class AsyncCompletions(BaseCompletions[AsyncGPTModel]):
     _model_type = AsyncGPTModel


### PR DESCRIPTION
This PR adds missing generic parameters to the `Completions` classes. Without them currently Pylance reports the type of `sdk.models.completions("yandexgpt")` as `Unknown`.